### PR TITLE
CM-41236 - Code refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+## [1.6.1] - 2024-10-31
+
+- Code refactoring
+
 ## [1.6.0] - 2024-10-07
 
 - Add sync flow for Secrets and IaC
@@ -65,6 +69,8 @@
 
 The first public release of the extension.
 
+[1.6.1]: https://github.com/cycodehq/visual-studio-extension/releases/tag/v1.6.1
+
 [1.6.0]: https://github.com/cycodehq/visual-studio-extension/releases/tag/v1.6.0
 
 [1.5.1]: https://github.com/cycodehq/visual-studio-extension/releases/tag/v1.5.1
@@ -91,4 +97,4 @@ The first public release of the extension.
 
 [1.0.0]: https://github.com/cycodehq/visual-studio-extension/releases/tag/v1.0.0
 
-[Unreleased]: https://github.com/cycodehq/visual-studio-extension/compare/v1.6.0...HEAD
+[Unreleased]: https://github.com/cycodehq/visual-studio-extension/compare/v1.6.1...HEAD

--- a/src/extension/Cycode.VisualStudio.Extension.14.0-16.0/Cycode.VisualStudio.Extension.14.0-16.0.csproj
+++ b/src/extension/Cycode.VisualStudio.Extension.14.0-16.0/Cycode.VisualStudio.Extension.14.0-16.0.csproj
@@ -74,7 +74,7 @@
   <ItemGroup>
     <PackageReference Include="Community.VisualStudio.Toolkit.14" Version="14.0.507"/>
     <PackageReference Include="Community.VisualStudio.VSCT" Version="16.0.29.6"/>
-    <PackageReference Include="MdXaml" Version="1.27.0" />
+    <PackageReference Include="MdXaml" Version="1.27.0"/>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0"/>
     <PackageReference Include="Sentry" Version="4.9.0"/>
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4"/>

--- a/src/extension/Cycode.VisualStudio.Extension.14.0-16.0/source.extension.vsixmanifest
+++ b/src/extension/Cycode.VisualStudio.Extension.14.0-16.0/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Cycode.7e1a0714-9b3b-4e0e-9c0a-d23fb20ab86e" Version="1.6.0" Language="en-US" Publisher="cycodehq" />
+        <Identity Id="Cycode.7e1a0714-9b3b-4e0e-9c0a-d23fb20ab86e" Version="1.6.1" Language="en-US" Publisher="cycodehq" />
         <DisplayName>Cycode</DisplayName>
         <Description xml:space="preserve">Cycode for Visual Studio IDE</Description>
         <MoreInfo>https://github.com/cycodehq/visual-studio-extension</MoreInfo>

--- a/src/extension/Cycode.VisualStudio.Extension.17.0/Cycode.VisualStudio.Extension.17.0.csproj
+++ b/src/extension/Cycode.VisualStudio.Extension.17.0/Cycode.VisualStudio.Extension.17.0.csproj
@@ -74,7 +74,7 @@
   <ItemGroup>
     <PackageReference Include="Community.VisualStudio.Toolkit.17" Version="17.0.507"/>
     <PackageReference Include="Community.VisualStudio.VSCT" Version="16.0.29.6"/>
-    <PackageReference Include="MdXaml" Version="1.27.0" />
+    <PackageReference Include="MdXaml" Version="1.27.0"/>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0"/>
     <PackageReference Include="Sentry" Version="4.9.0"/>
     <PackageReference Include="System.Net.Http" Version="4.3.4"/>

--- a/src/extension/Cycode.VisualStudio.Extension.17.0/source.extension.vsixmanifest
+++ b/src/extension/Cycode.VisualStudio.Extension.17.0/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Cycode.f2c5020e-67a2-46f8-a888-609412fd59db" Version="1.6.0" Language="en-US" Publisher="cycodehq" />
+        <Identity Id="Cycode.f2c5020e-67a2-46f8-a888-609412fd59db" Version="1.6.1" Language="en-US" Publisher="cycodehq" />
         <DisplayName>Cycode</DisplayName>
         <Description xml:space="preserve">Cycode for Visual Studio IDE</Description>
         <MoreInfo>https://github.com/cycodehq/visual-studio-extension</MoreInfo>

--- a/src/extension/Cycode.VisualStudio.Extension.Shared/Commands/RunAllScansCommand.cs
+++ b/src/extension/Cycode.VisualStudio.Extension.Shared/Commands/RunAllScansCommand.cs
@@ -1,4 +1,5 @@
-﻿using Cycode.VisualStudio.Extension.Shared.DTO;
+﻿using Cycode.VisualStudio.Extension.Shared.Cli.DTO;
+using Cycode.VisualStudio.Extension.Shared.DTO;
 using Cycode.VisualStudio.Extension.Shared.Services;
 
 namespace Cycode.VisualStudio.Extension.Shared.Commands;
@@ -20,10 +21,10 @@ internal sealed class RunAllScansCommand : BaseCommand<RunAllScansCommand> {
         try {
             ICycodeService cycode = ServiceLocator.GetService<ICycodeService>();
             await Task.WhenAll(
-                cycode.StartSecretScanForCurrentProjectAsync(),
-                cycode.StartScaScanForCurrentProjectAsync(),
-                cycode.StartIacScanForCurrentProjectAsync(),
-                cycode.StartSastScanForCurrentProjectAsync()
+                cycode.StartProjectScanAsync(CliScanType.Secret),
+                cycode.StartProjectScanAsync(CliScanType.Sca),
+                cycode.StartProjectScanAsync(CliScanType.Iac),
+                cycode.StartProjectScanAsync(CliScanType.Sast)
             );
         } finally {
             Command.Enabled = true;

--- a/src/extension/Cycode.VisualStudio.Extension.Shared/Components/ToolWindows/MainControl.xaml.cs
+++ b/src/extension/Cycode.VisualStudio.Extension.Shared/Components/ToolWindows/MainControl.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System.Windows;
 using System.Windows.Controls;
+using Cycode.VisualStudio.Extension.Shared.Cli.DTO;
 using Cycode.VisualStudio.Extension.Shared.Services;
 
 namespace Cycode.VisualStudio.Extension.Shared.Components.ToolWindows;
@@ -16,7 +17,7 @@ public partial class MainControl {
         string originalContent = button.Content.ToString();
 
         button.IsEnabled = false;
-        button.Content = "Scanning...";
+        button.Content = originalContent + "...";
 
         try {
             await action();
@@ -29,7 +30,7 @@ public partial class MainControl {
     private async void ScanSecretsClickAsync(object sender, RoutedEventArgs e) {
         await ExecuteWithButtonStateAsync(ScanSecretsBtn, async () => {
             try {
-                await Cycode.StartSecretScanForCurrentProjectAsync();
+                await Cycode.StartProjectScanAsync(CliScanType.Secret);
             } catch (Exception ex) {
                 Logger.Error(ex, "Failed to scan secrets");
             }
@@ -39,7 +40,7 @@ public partial class MainControl {
     private async void ScanScaClickAsync(object sender, RoutedEventArgs e) {
         await ExecuteWithButtonStateAsync(ScanScaBtn, async () => {
             try {
-                await Cycode.StartScaScanForCurrentProjectAsync();
+                await Cycode.StartProjectScanAsync(CliScanType.Sca);
             } catch (Exception ex) {
                 Logger.Error(ex, "Failed to scan SCA");
             }
@@ -49,7 +50,7 @@ public partial class MainControl {
     private async void ScanIacClickAsync(object sender, RoutedEventArgs e) {
         await ExecuteWithButtonStateAsync(ScanIacBtn, async () => {
             try {
-                await Cycode.StartIacScanForCurrentProjectAsync();
+                await Cycode.StartProjectScanAsync(CliScanType.Iac);
             } catch (Exception ex) {
                 Logger.Error(ex, "Failed to scan IaC");
             }
@@ -59,7 +60,7 @@ public partial class MainControl {
     private async void ScanSastClickAsync(object sender, RoutedEventArgs e) {
         await ExecuteWithButtonStateAsync(ScanSastBtn, async () => {
             try {
-                await Cycode.StartSastScanForCurrentProjectAsync();
+                await Cycode.StartProjectScanAsync(CliScanType.Sast);
             } catch (Exception ex) {
                 Logger.Error(ex, "Failed to scan SAST");
             }

--- a/src/extension/Cycode.VisualStudio.Extension.Shared/Components/TreeView/CycodeTreeViewControl.xaml.cs
+++ b/src/extension/Cycode.VisualStudio.Extension.Shared/Components/TreeView/CycodeTreeViewControl.xaml.cs
@@ -112,10 +112,10 @@ public partial class CycodeTreeViewControl {
 
     private void CreateDetectionNodes(
         CliScanType scanType,
-        ScanResultBase scanResults,
+        IEnumerable<DetectionBase> detections,
         Func<DetectionBase, BaseNode> createNodeCallback
     ) {
-        List<DetectionBase> sortedDetections = scanResults.GetDetections()
+        List<DetectionBase> sortedDetections = detections
             .OrderByDescending(detection => GetSeverityWeight(detection.Severity))
             .ToList();
         IEnumerable<IGrouping<string, DetectionBase>> detectionsByFile =
@@ -140,10 +140,9 @@ public partial class CycodeTreeViewControl {
     }
 
     private void CreateSecretDetectionNodes() {
-        SecretScanResult secretResults = _scanResultsService.GetSecretResults();
-        if (secretResults == null) return;
+        IEnumerable<DetectionBase> detections = _scanResultsService.GetDetections(CliScanType.Secret);
 
-        CreateDetectionNodes(CliScanType.Secret, secretResults, detectionBase => {
+        CreateDetectionNodes(CliScanType.Secret, detections, detectionBase => {
             SecretDetection detection = (SecretDetection)detectionBase;
             SecretDetectionNode node = new() {
                 Title = detection.GetFormattedNodeTitle(),
@@ -156,10 +155,9 @@ public partial class CycodeTreeViewControl {
     }
 
     private void CreateScaDetectionNodes() {
-        ScaScanResult scaResults = _scanResultsService.GetScaResults();
-        if (scaResults == null) return;
+        IEnumerable<DetectionBase> detections = _scanResultsService.GetDetections(CliScanType.Sca);
 
-        CreateDetectionNodes(CliScanType.Sca, scaResults, detectionBase => {
+        CreateDetectionNodes(CliScanType.Sca, detections, detectionBase => {
             ScaDetection detection = (ScaDetection)detectionBase;
             ScaDetectionNode node = new() {
                 Title = detection.GetFormattedNodeTitle(),
@@ -172,10 +170,9 @@ public partial class CycodeTreeViewControl {
     }
 
     private void CreateIacDetectionNodes() {
-        IacScanResult iacResults = _scanResultsService.GetIacResults();
-        if (iacResults == null) return;
+        IEnumerable<DetectionBase> detections = _scanResultsService.GetDetections(CliScanType.Iac);
 
-        CreateDetectionNodes(CliScanType.Iac, iacResults, detectionBase => {
+        CreateDetectionNodes(CliScanType.Iac, detections, detectionBase => {
             IacDetection detection = (IacDetection)detectionBase;
             IacDetectionNode node = new() {
                 Title = detection.GetFormattedNodeTitle(),
@@ -188,10 +185,9 @@ public partial class CycodeTreeViewControl {
     }
 
     private void CreateSastDetectionNodes() {
-        SastScanResult sastResults = _scanResultsService.GetSastResults();
-        if (sastResults == null) return;
+        IEnumerable<DetectionBase> detections = _scanResultsService.GetDetections(CliScanType.Sast);
 
-        CreateDetectionNodes(CliScanType.Sast, sastResults, detectionBase => {
+        CreateDetectionNodes(CliScanType.Sast, detections, detectionBase => {
             SastDetection detection = (SastDetection)detectionBase;
             SastDetectionNode node = new() {
                 Title = detection.GetFormattedNodeTitle(),

--- a/src/extension/Cycode.VisualStudio.Extension.Shared/CycodePackage.cs
+++ b/src/extension/Cycode.VisualStudio.Extension.Shared/CycodePackage.cs
@@ -4,6 +4,7 @@ global using Microsoft.VisualStudio.Shell;
 global using Task = System.Threading.Tasks.Task;
 using System.Runtime.InteropServices;
 using System.Threading;
+using Community.VisualStudio.Toolkit;
 using Cycode.VisualStudio.Extension.Shared.Components.ToolWindows;
 using Cycode.VisualStudio.Extension.Shared.Options;
 using Cycode.VisualStudio.Extension.Shared.Sentry;
@@ -11,6 +12,7 @@ using Cycode.VisualStudio.Extension.Shared.Services;
 using Cycode.VisualStudio.Extension.Shared.Services.ErrorList;
 using Cycode.VisualStudio.Extension.Shared.Services.ErrorTagger;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.Shell;
 
 namespace Cycode.VisualStudio.Extension.Shared;
 

--- a/src/extension/Cycode.VisualStudio.Extension.Shared/Services/DocTableEventsHandlerService.cs
+++ b/src/extension/Cycode.VisualStudio.Extension.Shared/Services/DocTableEventsHandlerService.cs
@@ -133,9 +133,9 @@ public class DocTableEventsHandlerService(
 
         // Wait for all three await calls to complete
         await Task.WhenAll(
-            pathsToScan.Any() ? cycode.StartPathSecretScanAsync(pathsToScan) : Task.CompletedTask,
-            scaPathsToScan.Any() ? cycode.StartPathScaScanAsync(scaPathsToScan) : Task.CompletedTask,
-            iacPathsToScan.Any() ? cycode.StartPathIacScanAsync(iacPathsToScan) : Task.CompletedTask
+            pathsToScan.Any() ? cycode.StartPathScanAsync(CliScanType.Secret, pathsToScan) : Task.CompletedTask,
+            scaPathsToScan.Any() ? cycode.StartPathScanAsync(CliScanType.Sca, scaPathsToScan) : Task.CompletedTask,
+            iacPathsToScan.Any() ? cycode.StartPathScanAsync(CliScanType.Iac, iacPathsToScan) : Task.CompletedTask
         );
     }
 

--- a/src/extension/Cycode.VisualStudio.Extension.Shared/Services/ErrorList/TaskCreators/IacErrorTaskCreator.cs
+++ b/src/extension/Cycode.VisualStudio.Extension.Shared/Services/ErrorList/TaskCreators/IacErrorTaskCreator.cs
@@ -5,10 +5,10 @@ using Cycode.VisualStudio.Extension.Shared.Cli.DTO.ScanResult.Iac;
 namespace Cycode.VisualStudio.Extension.Shared.Services.ErrorList.TaskCreators;
 
 public static class IacErrorTaskCreator {
-    public static List<ErrorTask> CreateErrorTasks(IacScanResult scanResult) {
+    public static List<ErrorTask> CreateErrorTasks(List<IacDetection> detections) {
         List<ErrorTask> errorTasks = [];
 
-        errorTasks.AddRange(scanResult.Detections.Select(detection => new ErrorTask {
+        errorTasks.AddRange(detections.Select(detection => new ErrorTask {
             Text = $"Cycode: {detection.GetFormattedTitle()}",
             Line = detection.DetectionDetails.LineInFile,
             Document = detection.DetectionDetails.GetFilePath(),

--- a/src/extension/Cycode.VisualStudio.Extension.Shared/Services/ErrorList/TaskCreators/SastErrorTaskCreator.cs
+++ b/src/extension/Cycode.VisualStudio.Extension.Shared/Services/ErrorList/TaskCreators/SastErrorTaskCreator.cs
@@ -5,10 +5,10 @@ using Cycode.VisualStudio.Extension.Shared.Cli.DTO.ScanResult.Sast;
 namespace Cycode.VisualStudio.Extension.Shared.Services.ErrorList.TaskCreators;
 
 public static class SastErrorTaskCreator {
-    public static List<ErrorTask> CreateErrorTasks(SastScanResult scanResult) {
+    public static List<ErrorTask> CreateErrorTasks(List<SastDetection> detections) {
         List<ErrorTask> errorTasks = [];
 
-        errorTasks.AddRange(scanResult.Detections.Select(detection => new ErrorTask {
+        errorTasks.AddRange(detections.Select(detection => new ErrorTask {
             Text = $"Cycode: {detection.GetFormattedTitle()}",
             Line = detection.DetectionDetails.LineInFile - 1,
             Document = detection.DetectionDetails.GetFilePath(),

--- a/src/extension/Cycode.VisualStudio.Extension.Shared/Services/ErrorList/TaskCreators/ScaErrorTaskCreator.cs
+++ b/src/extension/Cycode.VisualStudio.Extension.Shared/Services/ErrorList/TaskCreators/ScaErrorTaskCreator.cs
@@ -5,10 +5,10 @@ using Cycode.VisualStudio.Extension.Shared.Cli.DTO.ScanResult.Sca;
 namespace Cycode.VisualStudio.Extension.Shared.Services.ErrorList.TaskCreators;
 
 public static class ScaErrorTaskCreator {
-    public static List<ErrorTask> CreateErrorTasks(ScaScanResult scanResult) {
+    public static List<ErrorTask> CreateErrorTasks(List<ScaDetection> detections) {
         List<ErrorTask> errorTasks = [];
 
-        errorTasks.AddRange(scanResult.Detections.Select(detection => new ErrorTask {
+        errorTasks.AddRange(detections.Select(detection => new ErrorTask {
             Text = $"Cycode: {detection.GetFormattedTitle()}",
             Line = detection.DetectionDetails.LineInFile - 1,
             Document = detection.DetectionDetails.GetFilePath(),

--- a/src/extension/Cycode.VisualStudio.Extension.Shared/Services/ErrorList/TaskCreators/SecretsErrorTaskCreator.cs
+++ b/src/extension/Cycode.VisualStudio.Extension.Shared/Services/ErrorList/TaskCreators/SecretsErrorTaskCreator.cs
@@ -5,10 +5,10 @@ using Cycode.VisualStudio.Extension.Shared.Cli.DTO.ScanResult.Secret;
 namespace Cycode.VisualStudio.Extension.Shared.Services.ErrorList.TaskCreators;
 
 public static class SecretsErrorTaskCreator {
-    public static List<ErrorTask> CreateErrorTasks(SecretScanResult scanResult) {
+    public static List<ErrorTask> CreateErrorTasks(List<SecretDetection> detections) {
         List<ErrorTask> errorTasks = [];
 
-        errorTasks.AddRange(scanResult.Detections.Select(detection => new ErrorTask {
+        errorTasks.AddRange(detections.Select(detection => new ErrorTask {
             Text = $"Cycode: {detection.GetFormattedTitle()}",
             Line = detection.DetectionDetails.Line,
             Document = detection.DetectionDetails.GetFilePath(),

--- a/src/extension/Cycode.VisualStudio.Extension.Shared/Services/ErrorTagger/TagSpansCreators/IacTagSpansCreator.cs
+++ b/src/extension/Cycode.VisualStudio.Extension.Shared/Services/ErrorTagger/TagSpansCreators/IacTagSpansCreator.cs
@@ -14,11 +14,8 @@ public static class IacTagSpansCreator {
     public static List<ITagSpan<DetectionTag>> CreateTagSpans(ITextSnapshot snapshot, ITextDocument document) {
         List<ITagSpan<DetectionTag>> tagSpans = [];
 
-        IacScanResult iacScanResult = _scanResultsService.GetIacResults();
-        if (iacScanResult == null) return tagSpans;
-
         string normalizedFilePath = Path.GetFullPath(document.FilePath);
-        List<IacDetection> detections = iacScanResult.Detections
+        List<IacDetection> detections = _scanResultsService.GetIacDetections()
             .Where(detection => {
                 string normalizedDetectionPath = Path.GetFullPath(detection.DetectionDetails.GetFilePath());
                 return normalizedFilePath == normalizedDetectionPath;

--- a/src/extension/Cycode.VisualStudio.Extension.Shared/Services/ErrorTagger/TagSpansCreators/SastTagSpansCreator.cs
+++ b/src/extension/Cycode.VisualStudio.Extension.Shared/Services/ErrorTagger/TagSpansCreators/SastTagSpansCreator.cs
@@ -14,11 +14,8 @@ public static class SastTagSpansCreator {
     public static List<ITagSpan<DetectionTag>> CreateTagSpans(ITextSnapshot snapshot, ITextDocument document) {
         List<ITagSpan<DetectionTag>> tagSpans = [];
 
-        SastScanResult sastScanResult = _scanResultsService.GetSastResults();
-        if (sastScanResult == null) return tagSpans;
-
         string normalizedFilePath = Path.GetFullPath(document.FilePath);
-        List<SastDetection> detections = sastScanResult.Detections
+        List<SastDetection> detections = _scanResultsService.GetSastDetections()
             .Where(detection => {
                 string normalizedDetectionPath = Path.GetFullPath(detection.DetectionDetails.GetFilePath());
                 return normalizedFilePath == normalizedDetectionPath;

--- a/src/extension/Cycode.VisualStudio.Extension.Shared/Services/ErrorTagger/TagSpansCreators/ScaTagSpansCreator.cs
+++ b/src/extension/Cycode.VisualStudio.Extension.Shared/Services/ErrorTagger/TagSpansCreators/ScaTagSpansCreator.cs
@@ -14,11 +14,8 @@ public static class ScaTagSpansCreator {
     public static List<ITagSpan<DetectionTag>> CreateTagSpans(ITextSnapshot snapshot, ITextDocument document) {
         List<ITagSpan<DetectionTag>> tagSpans = [];
 
-        ScaScanResult scaScanResult = _scanResultsService.GetScaResults();
-        if (scaScanResult == null) return tagSpans;
-
         string normalizedFilePath = Path.GetFullPath(document.FilePath);
-        List<ScaDetection> detections = scaScanResult.Detections
+        List<ScaDetection> detections = _scanResultsService.GetScaDetections()
             .Where(detection => {
                 string normalizedDetectionPath = Path.GetFullPath(detection.DetectionDetails.GetFilePath());
                 return normalizedFilePath == normalizedDetectionPath;

--- a/src/extension/Cycode.VisualStudio.Extension.Shared/Services/ErrorTagger/TagSpansCreators/SecretsTagSpansCreator.cs
+++ b/src/extension/Cycode.VisualStudio.Extension.Shared/Services/ErrorTagger/TagSpansCreators/SecretsTagSpansCreator.cs
@@ -14,11 +14,8 @@ public static class SecretsTagSpansCreator {
     public static List<ITagSpan<DetectionTag>> CreateTagSpans(ITextSnapshot snapshot, ITextDocument document) {
         List<ITagSpan<DetectionTag>> tagSpans = [];
 
-        SecretScanResult secretScanResult = _scanResultsService.GetSecretResults();
-        if (secretScanResult == null) return tagSpans;
-
         string normalizedFilePath = Path.GetFullPath(document.FilePath);
-        List<SecretDetection> detections = secretScanResult.Detections
+        List<SecretDetection> detections = _scanResultsService.GetSecretDetections()
             .Where(detection => {
                 string normalizedDetectionPath = Path.GetFullPath(detection.DetectionDetails.GetFilePath());
                 return normalizedFilePath == normalizedDetectionPath;

--- a/src/extension/Cycode.VisualStudio.Extension.Shared/source.extension.cs
+++ b/src/extension/Cycode.VisualStudio.Extension.Shared/source.extension.cs
@@ -3,5 +3,5 @@ namespace Cycode.VisualStudio.Extension.Shared;
 internal sealed class Vsix {
     public const string Name = "Cycode";
     public const string Description = "Cycode for Visual Studio IDE";
-    public const string Version = "1.6.0";
+    public const string Version = "1.6.1";
 }


### PR DESCRIPTION
the main idea is to use `.FireAndForget()` as less as possible (i predict that it leads to UI rendering problems; also, it silences exceptions); and reuse code for scanners